### PR TITLE
Changed *.less default suffixes to *.scss

### DIFF
--- a/config/generators.php
+++ b/config/generators.php
@@ -21,7 +21,7 @@ return [
             'config'          => '.config.js',
             'filter'          => '.filter.js',
             'pageView'        => '.page.html',
-            'stylesheet'      => 'less', // less, scss or css
+            'stylesheet'      => 'scss', // less, scss or css
       ],
       'tests' => [
             'enable' => [

--- a/src/Console/Commands/AngularComponent.php
+++ b/src/Console/Commands/AngularComponent.php
@@ -73,7 +73,7 @@ class AngularComponent extends Command
         File::put($folder.'/'.$name.config('generators.suffix.component'), $js);
 
         //create style file
-        File::put($folder.'/'.$name.'.'.config('generators.suffix.stylesheet', 'less'), $style);
+        File::put($folder.'/'.$name.'.'.config('generators.suffix.stylesheet', 'scss'), $style);
 
         if (!$this->option('no-spec') && config('generators.tests.enable.components')) {
             //create spec file (.component.spec.js)

--- a/src/Console/Commands/AngularPage.php
+++ b/src/Console/Commands/AngularPage.php
@@ -74,7 +74,7 @@ class AngularPage extends Command
         File::put($folder.'/'.$name.config('generators.suffix.pageView'), $html);
 
         //create style file
-        File::put($folder.'/'.$name.'.'.config('generators.suffix.stylesheet', 'less'), $style);
+        File::put($folder.'/'.$name.'.'.config('generators.suffix.stylesheet', 'scss'), $style);
 
         $this->info('Page created successfully.');
     }


### PR DESCRIPTION
Small changes to use scss as the default pre-processor for generated stylesheets. This corresponds with my other pull request at jadjoubran/laravel5-angular-material-starter/pull/350.
