### PR TITLE
Fixed #34: Create tests subfolders

### DIFF
--- a/src/Console/Commands/AngularComponent.php
+++ b/src/Console/Commands/AngularComponent.php
@@ -76,6 +76,10 @@ class AngularComponent extends Command
         File::put($folder.'/'.$name.'.'.config('generators.suffix.stylesheet', 'scss'), $style);
 
         if (!$this->option('no-spec') && config('generators.tests.enable.components')) {
+            //create spec folder
+            if (!File::exists($spec_folder)) {
+                File::makeDirectory($spec_folder, 0775, true);
+            }
             //create spec file (.component.spec.js)
             File::put($spec_folder.'/'.$name.'.component.spec.js', $spec);
         }

--- a/src/Console/Commands/AngularDirective.php
+++ b/src/Console/Commands/AngularDirective.php
@@ -68,6 +68,10 @@ class AngularDirective extends Command
         File::put($folder.'/'.$name.config('generators.suffix.directive'), $js);
 
         if (!$this->option('no-spec') && config('generators.tests.enable.directives')) {
+            //create spec folder
+            if (!File::exists($spec_folder)) {
+                File::makeDirectory($spec_folder, 0775, true);
+            }
             //create spec file (.directive.spec.js)
             File::put($spec_folder.'/'.$name.'.directive.spec.js', $spec);
         }

--- a/src/Console/Commands/AngularService.php
+++ b/src/Console/Commands/AngularService.php
@@ -57,6 +57,11 @@ class AngularService extends Command
         File::put($folder.'/'.$name.config('generators.suffix.service'), $js);
 
         if (!$this->option('no-spec') && config('generators.tests.enable.services')) {
+            //create spec folder
+            if (!File::exists($spec_folder)) {
+                File::makeDirectory($spec_folder, 0775, true);
+            }
+            
             //create spec (.service.spec.js)
             File::put($spec_folder.'/'.$name.'.service.spec.js', $spec);
         }

--- a/src/Console/Commands/AngularService.php
+++ b/src/Console/Commands/AngularService.php
@@ -61,7 +61,6 @@ class AngularService extends Command
             if (!File::exists($spec_folder)) {
                 File::makeDirectory($spec_folder, 0775, true);
             }
-            
             //create spec (.service.spec.js)
             File::put($spec_folder.'/'.$name.'.service.spec.js', $spec);
         }


### PR DESCRIPTION
Create tests/angular/components subfolders if they don't exist.
