### PR TITLE
Component creation now allows to be created inside a subdirectory

### DIFF
--- a/src/Console/Commands/AngularComponent.php
+++ b/src/Console/Commands/AngularComponent.php
@@ -40,7 +40,23 @@ class AngularComponent extends Command
      */
     public function handle()
     {
-        $name = $this->argument('name');
+        // Gets the argument and split it into an array
+        $pathArray = explode('/', $this->argument('name'));
+
+        // Gets the last element of the array, that it should be the name of the component
+        $name = end($pathArray);
+
+        // Deletes the last element of the Array (we store it in the variable $name)
+        array_pop($pathArray);
+
+        // Initialize the variable $path with a '/' cause if the array <= 0 it means there's no path, and we should use the deafult route
+        $path = '/';
+
+        // We iterate through the array to concatenat it again, adding always a '/' at the end of each array element
+        foreach ($pathArray as $value) {
+            $path = $path.$value.'/';
+        }
+
         $studly_name = studly_case($name);
         $ng_component = str_replace('_', '-', $name);
 
@@ -51,10 +67,11 @@ class AngularComponent extends Command
 
         $js = str_replace('{{StudlyName}}', $studly_name, $js);
         $js = str_replace('{{name}}', $name, $js);
+        $js = str_replace('{{path}}', $path, $js);
 
         $spec = str_replace('{{ng-component}}', $ng_component, $spec);
 
-        $folder = base_path(config('generators.source.root')).'/'.config('generators.source.components').'/'.$name;
+        $folder = base_path(config('generators.source.root')).'/'.config('generators.source.components').$path.$name;
         if (is_dir($folder)) {
             $this->info('Folder already exists');
 
@@ -92,7 +109,7 @@ class AngularComponent extends Command
             $newComponent = "\r\n\t.component('$componentName', {$studly_name}Component)";
             $module = "angular.module('app.components')";
             $components = str_replace($module, $module.$newComponent, $components);
-            $components = 'import {'.$studly_name."Component} from './app/components/{$name}/{$name}.component';\n".$components;
+            $components = 'import {'.$studly_name."Component} from './app/components{$path}{$name}/{$name}.component';\n".$components;
             file_put_contents($components_index, $components);
         }
 

--- a/src/Console/Commands/AngularComponent.php
+++ b/src/Console/Commands/AngularComponent.php
@@ -1,7 +1,10 @@
 <?php
+
 namespace LaravelAngular\Generators\Console\Commands;
+
 use File;
 use Illuminate\Console\Command;
+
 class AngularComponent extends Command
 {
     /**
@@ -19,6 +22,7 @@ class AngularComponent extends Command
      * @var string
      */
     protected $description = 'Create a new component in angular/components';
+
     /**
      * Create a new command instance.
      *
@@ -28,6 +32,7 @@ class AngularComponent extends Command
     {
         parent::__construct();
     }
+
     /**
      * Execute the console command.
      *
@@ -72,6 +77,7 @@ class AngularComponent extends Command
         $folder = base_path(config('generators.source.root')).'/'.config('generators.source.components').$path.$name;
         if (is_dir($folder)) {
             $this->info('Folder already exists');
+
             return false;
         }
         $spec_folder = base_path(config('generators.tests.source.root')).'/'.config('generators.tests.source.components');

--- a/src/Console/Commands/AngularComponent.php
+++ b/src/Console/Commands/AngularComponent.php
@@ -1,10 +1,7 @@
 <?php
-
 namespace LaravelAngular\Generators\Console\Commands;
-
 use File;
 use Illuminate\Console\Command;
-
 class AngularComponent extends Command
 {
     /**
@@ -12,17 +9,16 @@ class AngularComponent extends Command
      *
      * @var string
      */
-    protected $signature = 'ng:component {name}
+    protected $signature = 'ng:component {name : can include subdir e.g. admin/name result admin/admin-name/admin-name.component.js or see no-prefix}
     {--no-spec : Don\'t create a test file}
-    {--no-import : Don\'t auto import in index.components}';
-
+    {--no-import : Don\'t auto import in index.components}
+    {--no-prefix : Don\'t prefix component name after subdir e.g. <subdir>/name result <subdir>/name/name.component.js}';
     /**
      * The console command description.
      *
      * @var string
      */
     protected $description = 'Create a new component in angular/components';
-
     /**
      * Create a new command instance.
      *
@@ -32,7 +28,6 @@ class AngularComponent extends Command
     {
         parent::__construct();
     }
-
     /**
      * Execute the console command.
      *
@@ -42,56 +37,52 @@ class AngularComponent extends Command
     {
         // Gets the argument and split it into an array
         $pathArray = explode('/', $this->argument('name'));
-
         // Gets the last element of the array, that it should be the name of the component
         $name = end($pathArray);
-
         // Deletes the last element of the Array (we store it in the variable $name)
         array_pop($pathArray);
-
+        // Prefixes component after subdirectory path that contains it, to help avoid duplicated component names
+        // e.g. components/admin/dashboard/dashboard.component.js
+        //      components/users/dashboard/dashboard.component.js <-- duplicated to admin's dashboard component and will fail on import
+        //  to: components/admin/admin-dashboard/admin-dashboard.component.js
+        //  or: components/users/users-dashboard/users-dashboard.component.js <-- conveniently prefixed won't fail on import
+        if (!$this->option('no-prefix')) {
+            $prefix = '';
+            foreach ($pathArray as $value) {
+                $prefix = $prefix.$value.'-';
+            }
+            $name = $prefix.$name;
+        }
         // Initialize the variable $path with a '/' cause if the array <= 0 it means there's no path, and we should use the deafult route
         $path = '/';
-
         // We iterate through the array to concatenat it again, adding always a '/' at the end of each array element
         foreach ($pathArray as $value) {
             $path = $path.$value.'/';
         }
-
         $studly_name = studly_case($name);
         $ng_component = str_replace('_', '-', $name);
-
         $html = file_get_contents(__DIR__.'/Stubs/AngularComponent/component.html.stub');
         $js = file_get_contents(__DIR__.'/Stubs/AngularComponent/component.js.stub');
         $style = file_get_contents(__DIR__.'/Stubs/AngularComponent/component.style.stub');
         $spec = file_get_contents(__DIR__.'/Stubs/AngularComponent/component.spec.js.stub');
-
         $js = str_replace('{{StudlyName}}', $studly_name, $js);
         $js = str_replace('{{name}}', $name, $js);
         $js = str_replace('{{path}}', $path, $js);
-
         $spec = str_replace('{{ng-component}}', $ng_component, $spec);
-
         $folder = base_path(config('generators.source.root')).'/'.config('generators.source.components').$path.$name;
         if (is_dir($folder)) {
             $this->info('Folder already exists');
-
             return false;
         }
-
         $spec_folder = base_path(config('generators.tests.source.root')).'/'.config('generators.tests.source.components');
-
         //create folder
         File::makeDirectory($folder, 0775, true);
-
         //create view (.component.html)
         File::put($folder.'/'.$name.config('generators.suffix.componentView'), $html);
-
         //create component (.component.js)
         File::put($folder.'/'.$name.config('generators.suffix.component'), $js);
-
         //create style file
         File::put($folder.'/'.$name.'.'.config('generators.suffix.stylesheet', 'scss'), $style);
-
         if (!$this->option('no-spec') && config('generators.tests.enable.components')) {
             //create spec folder
             if (!File::exists($spec_folder)) {
@@ -100,7 +91,6 @@ class AngularComponent extends Command
             //create spec file (.component.spec.js)
             File::put($spec_folder.'/'.$name.'.component.spec.js', $spec);
         }
-
         //import component
         $components_index = base_path(config('generators.source.root')).'/index.components.js';
         if (config('generators.misc.auto_import') && !$this->option('no-import') && file_exists($components_index)) {
@@ -112,7 +102,6 @@ class AngularComponent extends Command
             $components = 'import {'.$studly_name."Component} from './app/components{$path}{$name}/{$name}.component';\n".$components;
             file_put_contents($components_index, $components);
         }
-
         $this->info('Component created successfully.');
     }
 }

--- a/src/Console/Commands/Stubs/AngularComponent/component.js.stub
+++ b/src/Console/Commands/Stubs/AngularComponent/component.js.stub
@@ -14,4 +14,4 @@ export const {{StudlyName}}Component = {
     controller: {{StudlyName}}Controller,
     controllerAs: 'vm',
     bindings: {}
-}
+};

--- a/src/Console/Commands/Stubs/AngularComponent/component.js.stub
+++ b/src/Console/Commands/Stubs/AngularComponent/component.js.stub
@@ -10,8 +10,8 @@ class {{StudlyName}}Controller{
 }
 
 export const {{StudlyName}}Component = {
-    templateUrl: './views/app/components/{{name}}/{{name}}.component.html',
+    templateUrl: './views/app/components{{path}}{{name}}/{{name}}.component.html',
     controller: {{StudlyName}}Controller,
     controllerAs: 'vm',
     bindings: {}
-};
+}


### PR DESCRIPTION
This enhancement as mentioned in #38 will allow to create components inside a convenient subdirectory and by default will prefix its name after the subdirectory that contains it.

For instance, if we are creating a dashboard component for admin and users, one might like to create like this:

`php artisan ng:component admin/dashboard`

The component will be created inside components directory like: `components/admin/admin-dashboard/admin-dashboard.component.js`

So if the we want to create another and different dashboard component for users e.g.

`php artisan ng:component users/dashboard`

It will also be created similarly, but its name will be prefixed to avoid duplicated component names on import.
`components/users/users-dashboard/users-dashboard.component.js`

So, their names will result in different class names:
```
class AdminDashboardController{...

class UsersDashboarController{...
```

However, you can always disable that prepending feature with the added  `--no-prefix` option to allow only using the component name, if that is what you like.

e.g.

`php artisan ng:component --no-prefix admin/dashboard` 

It will be created as `components/admin/dashboard/dashboard.component.js` and its classname will be `class DashboardController{...`

So, now `ng:component` with `name` that includes subdirectories as mentioned above, is prefixed by default to conveniently avoid duplicated component names... and might also be a hint to help us figure out in which directory is located our component, so we could find it easily. Notice that not using subdirectories, creation of components will behave as usual.