### PR TITLE
Added features, Laravel 5.6 compatibility, fixed bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor
+/.vscode

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ php artisan ng:filter name     #New filter inside angular/filters/
 php artisan ng:service name    #New service inside angular/services/
 ```
 
-Theese commands will create new directories and files for AngularJS front-end in new ES6 syntax. 
+These commands will create new directories and files for AngularJS front-end in new ES6 syntax. 
 If not present, commands will create index files (i.e.: `index.components.js`) and, if enabled, new created classes will be imported.
 
 Configurations are editable in `config\generators.php`. See below for details.
@@ -44,7 +44,7 @@ Configurations are editable in `config\generators.php`. See below for details.
    * **enable**: whether to enable or disable creation of test files
    * **source**: same as `source`, but for test files
 * **misc.auto_import**: enable or disable automatic import in index files.
-* **angular_modules**: configuration for angular root module and submodules. If index files are created before or manually, theese settings will help recognize angular modules for automatic import. If index file is created on first command run, theese settings will create angular module for you.
+* **angular_modules**: configuration for angular root module and submodules. If index files are created before or manually, these settings will help recognize angular modules for automatic import. If index file is created on first command run, these settings will create angular module for you.
    * **root**: angular root module.
    * **standalone**: if a module is defined as standalone (i.e.: `angular.module('mymodule', [])`) or is part of a root module (`angular.module('mymodule')`). If set to false, `use_prefix`, `prefix` and `suffix` will be ignored and root module name will be used.
    * **prefix** and **suffix**: name of module of the type `prefix.suffix`; i.e.: `app.components`.

--- a/README.md
+++ b/README.md
@@ -3,17 +3,6 @@
 Angular generators for Artisan. Originally created at [laravel5-angular-material-starter](https://github.com/jadjoubran/laravel5-angular-material-starter).
 
 
-# Usage
-
-```
-artisan ng:page name       #New page inside angular/app/pages/
-artisan ng:dialog name     #New custom dialog inside angular/dialogs/
-artisan ng:component name  #New component inside angular/app/components/
-artisan ng:service name    #New service inside angular/services/
-artisan ng:filter name     #New filter inside angular/filters/
-artisan ng:config name     #New config inside angular/config/
-```
-
 # Installation
 
 If you're using the starter project, then it's already pre-installed.
@@ -25,6 +14,41 @@ If you're using the starter project, then it's already pre-installed.
 
     php artisan vendor:publish
 
+
+# Usage
+
+```shell
+php artisan ng:page name       #New page inside angular/app/pages/
+php artisan ng:component name  #New component inside angular/app/components/
+php artisan ng:directive name  #New directive inside angular/directives/
+php artisan ng:config name     #New config inside angular/config/
+php artisan ng:dialog name     #New custom dialog inside angular/dialogs/
+php artisan ng:filter name     #New filter inside angular/filters/
+php artisan ng:service name    #New service inside angular/services/
+```
+
+Theese commands will create new directories and files for AngularJS front-end. 
+If not present, commands will create index files (i.e.: `index.components.js`) and, if enabled, new created classes will be imported.
+
+Configurations are editable in `config\generators.php`. See below for details.
+
+
+# Configuration
+
+* **source**: name of directories. They make a path to new created files
+   * **root**: name of the directory on where all created files and folders will be put.
+   * Other entries indicate directories where files will be put. I.e running `php artisan ng:component name` will be created three new files for component `name` with `root/components/name/` path. Default is `angular/app/components/name/`
+* **suffix**: name and extension appended to file name. I.e.: running `php artisan ng:directive name` will be created a file named `name.directive.js`.
+   * **stylesheet**: extension for stylesheets. NOTE: Stylesheets are created for both pages and components
+* **tests**
+   * **enable**: whether to enable or disable creation of test files
+   * **source**: same as `source`, but for test files
+* **misc.auto_import**: enable or disable automatic import in index files.
+* **angular_modules**: configuration for angular root module and submodules. If index files are created before or manually, theese settings will help recognize angular modules for automatic import. If index file is created on first command run, theese settings will create angular module for you.
+   * **root**: angular root module.
+   * **standalone**: if a module is defined as standalone (i.e.: `angular.module('mymodule', [])`) or is part of a root module (`angular.module('mymodule')`). If set to false, `use_prefix`, `prefix` and `suffix` will be ignored and root module name will be used.
+   * **prefix** and **suffix**: name of module of the type `prefix.suffix`; i.e.: `app.components`.
+   * **use_prefix**: whether to use prefix for module name
 
 # Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Laravel Angular Artisan Generators
+# Laravel AngularJS Artisan Generators
 
-Angular generators for Artisan. Originally created at [laravel5-angular-material-starter](https://github.com/jadjoubran/laravel5-angular-material-starter).
+AngularJS generators for Artisan. Originally created at [laravel5-angular-material-starter](https://github.com/jadjoubran/laravel5-angular-material-starter).
 
 
 # Installation
@@ -27,7 +27,7 @@ php artisan ng:filter name     #New filter inside angular/filters/
 php artisan ng:service name    #New service inside angular/services/
 ```
 
-Theese commands will create new directories and files for AngularJS front-end. 
+Theese commands will create new directories and files for AngularJS front-end in new ES6 syntax. 
 If not present, commands will create index files (i.e.: `index.components.js`) and, if enabled, new created classes will be imported.
 
 Configurations are editable in `config\generators.php`. See below for details.

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "illuminate/console": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*"
+        "illuminate/console": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.* || 5.6.*"
     },
     "autoload": {
         "psr-4": {

--- a/config/generators.php
+++ b/config/generators.php
@@ -39,4 +39,37 @@ return [
       'misc' => [
             'auto_import'         => true,
       ],
+      'angular_modules' => [
+            'root' => 'app',
+            'components' => [
+                  'standalone' => true,
+                  'use_prefix' => true,
+                  'prefix' => 'app',
+                  'suffix' => 'components'
+            ],
+            'directives' => [
+                  'standalone' => true,
+                  'use_prefix' => true,
+                  'prefix' => 'app',
+                  'suffix' => 'directives'
+            ],
+            'config' => [
+                  'standalone' => true,
+                  'use_prefix' => true,
+                  'prefix' => 'app',
+                  'suffix' => 'config'
+            ],
+            'filters' => [
+                  'standalone' => true,
+                  'use_prefix' => true,
+                  'prefix' => 'app',
+                  'suffix' => 'filters'
+            ],
+            'services' => [
+                  'standalone' => true,
+                  'use_prefix' => true,
+                  'prefix' => 'app',
+                  'suffix' => 'services'
+            ],
+      ]
 ];

--- a/config/generators.php
+++ b/config/generators.php
@@ -2,74 +2,74 @@
 
 return [
       'source' => [
-            'root'            => 'angular',
-            'page'            => 'app/pages',
-            'components'      => 'app/components',
-            'directives'      => 'directives',
-            'config'          => 'config',
-            'dialogs'         => 'dialogs',
-            'filters'         => 'filters',
-            'services'        => 'services',
+            'root'             => 'angular',
+            'page'             => 'app/pages',
+            'components'       => 'app/components',
+            'directives'       => 'directives',
+            'config'           => 'config',
+            'dialogs'          => 'dialogs',
+            'filters'          => 'filters',
+            'services'         => 'services',
       ],
       'suffix' => [
-            'component'       => '.component.js',
-            'componentView'   => '.component.html',
-            'dialog'          => '.dialog.js',
-            'dialogView'      => '.dialog.html',
-            'directive'       => '.directive.js',
-            'service'         => '.service.js',
-            'config'          => '.config.js',
-            'filter'          => '.filter.js',
-            'pageView'        => '.page.html',
-            'stylesheet'      => 'scss', // less, scss or css
+            'component'        => '.component.js',
+            'componentView'    => '.component.html',
+            'dialog'           => '.dialog.js',
+            'dialogView'       => '.dialog.html',
+            'directive'        => '.directive.js',
+            'service'          => '.service.js',
+            'config'           => '.config.js',
+            'filter'           => '.filter.js',
+            'pageView'         => '.page.html',
+            'stylesheet'       => 'scss', // less, scss or css
       ],
       'tests' => [
             'enable' => [
-                'components'      => true,
-                'services'        => true,
-                'directives'      => true,
+                'components'   => true,
+                'services'     => true,
+                'directives'   => true,
             ],
             'source' => [
-                'root'            => 'tests/angular/',
-                'components'      => 'app/components',
-                'directives'      => 'directives',
-                'services'        => 'services',
+                'root'         => 'tests/angular/',
+                'components'   => 'app/components',
+                'directives'   => 'directives',
+                'services'     => 'services',
             ],
       ],
       'misc' => [
-            'auto_import'         => true,
+            'auto_import'      => true,
       ],
       'angular_modules' => [
             'root' => 'app',
             'components' => [
                   'standalone' => true,
                   'use_prefix' => true,
-                  'prefix' => 'app',
-                  'suffix' => 'components'
+                  'prefix'     => 'app',
+                  'suffix'     => 'components'
             ],
             'directives' => [
                   'standalone' => true,
                   'use_prefix' => true,
-                  'prefix' => 'app',
-                  'suffix' => 'directives'
+                  'prefix'     => 'app',
+                  'suffix'     => 'directives'
             ],
             'config' => [
                   'standalone' => true,
                   'use_prefix' => true,
-                  'prefix' => 'app',
-                  'suffix' => 'config'
+                  'prefix'     => 'app',
+                  'suffix'     => 'config'
             ],
             'filters' => [
                   'standalone' => true,
                   'use_prefix' => true,
-                  'prefix' => 'app',
-                  'suffix' => 'filters'
+                  'prefix'     => 'app',
+                  'suffix'     => 'filters'
             ],
             'services' => [
                   'standalone' => true,
                   'use_prefix' => true,
-                  'prefix' => 'app',
-                  'suffix' => 'services'
+                  'prefix'     => 'app',
+                  'suffix'     => 'services'
             ],
       ]
 ];

--- a/src/Console/Commands/AngularComponent.php
+++ b/src/Console/Commands/AngularComponent.php
@@ -86,11 +86,22 @@ class AngularComponent extends Command
 
         //import component
         $components_index = base_path(config('generators.source.root')).'/index.components.js';
-        if (config('generators.misc.auto_import') && !$this->option('no-import') && file_exists($components_index)) {
+        
+        if(!config('generators.angular_modules.components.standalone'))
+            $module = "angular.module('".config('generators.angular_modules.root')."')";
+        else
+            $module = "angular.module('"
+                      .(config('generators.angular_modules.components.use_prefix') ? config('generators.angular_modules.components.prefix')."." : "")
+                      .config('generators.angular_modules.components.suffix')
+                      ."', [])";
+
+        if(!file_exists($components_index))
+            File::put($components_index, $module);
+
+        if (config('generators.misc.auto_import') && !$this->option('no-import')) {
             $components = file_get_contents($components_index);
             $componentName = lcfirst($studly_name);
             $newComponent = "\r\n\t.component('$componentName', {$studly_name}Component)";
-            $module = "angular.module('app.components')";
             $components = str_replace($module, $module.$newComponent, $components);
             $components = 'import {'.$studly_name."Component} from './app/components/{$name}/{$name}.component';\n".$components;
             file_put_contents($components_index, $components);

--- a/src/Console/Commands/AngularFilter.php
+++ b/src/Console/Commands/AngularFilter.php
@@ -49,16 +49,36 @@ class AngularFilter extends Command
 
         $folder = base_path(config('generators.source.root')).'/'.config('generators.source.filters');
 
+        if(!File::exists($folder))
+            File::makeDirectory($folder);
+        
         //create filter (.js)
-        File::put($folder.'/'.$name.config('generators.suffix.filter'), $js);
+        if(!File::exists($folder.'/'.$name.config('generators.suffix.filter')))
+            File::put($folder.'/'.$name.config('generators.suffix.filter'), $js);
+        else{
+            $this->info('Filter already exists.');
+            return false;
+        }
 
         //import filter
         $filters_index = base_path(config('generators.source.root')).'/index.filters.js';
-        if (config('generators.misc.auto_import') && !$this->option('no-import') && file_exists($filters_index)) {
+        
+        if(!config('generators.angular_modules.filters.standalone'))
+            $module = "angular.module('".config('generators.angular_modules.root')."')";
+        else
+            $module = "angular.module('"
+                      .(config('generators.angular_modules.filters.use_prefix') ? config('generators.angular_modules.filters.prefix')."." : "")
+                      .config('generators.angular_modules.filters.suffix')
+                      ."', [])";
+
+        if(!file_exists($filters_index)){
+            File::put($filters_index, $module);
+        }
+
+        if (config('generators.misc.auto_import') && !$this->option('no-import')) {
             $filters = file_get_contents($filters_index);
             $filterName = lcfirst($studly_name);
             $newFilters = "\r\n\t.filter('$filterName', {$studly_name}Filter)";
-            $module = "angular.module('app.filters')";
             $filters = str_replace($module, $module.$newFilters, $filters);
             $filters = 'import {'.$studly_name."Filter} from './filters/{$name}.filter';\n".$filters;
             file_put_contents($filters_index, $filters);


### PR DESCRIPTION
As from title, it has been improved compatibility adding 5.6.* version of illuminate famework and it's been fixed some bugs:

* folder creation: `AngularService.php` didn't create folder when missing. Added it.
* check for component (directive, etc.) presence before creating it: if same directive (i.e.) is created without checking for it's presence, the original file is overwritten losing all data
* removed creation of folder for every directive

It also has been added some features:

* creation of index files (i.e.: `index.components.js`)
* added settings for angular module: this improve module recognition if created manually by the user, and allow user to specify names of the modules and how they work with the root one